### PR TITLE
add ember-try files to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,8 @@
 bower.json
 ember-cli-build.js
 testem.js
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try


### PR DESCRIPTION
Looks like these files were accidentally published to NPM. They are currently taking up 89 megabytes when this package is installed.